### PR TITLE
Fixed Ending Screen Selection and Restart

### DIFF
--- a/Hold On Prototype/Assets/Scripts/GameEnding/EndScriptSelect.cs
+++ b/Hold On Prototype/Assets/Scripts/GameEnding/EndScriptSelect.cs
@@ -7,32 +7,49 @@ public class EndScriptSelect : MonoBehaviour
     public Sprite diedImage;
     public Sprite fledImage;
     public Sprite lostImage;
-    Image finalMessage; 
-
+    Image finalMessage;
     // Use this for initialization
     void Start()
     {
-        if(GameStateManager.fled) 
-        {
-         finalMessage = this.GetComponent<Image>();
-            finalMessage.sprite = fledImage;
-        }
-        if (GameStateManager.died)
-        {
-            finalMessage = this.GetComponent<Image>();
-            finalMessage.sprite = diedImage;
+        Debug.Log("Last Scene Started");
 
-        }
-        if (GameStateManager.lost)
+        if (GameStateManager.ending)
         {
+            if (GameStateManager.fled)
+            {
+                finalMessage = this.GetComponent<Image>();
+                finalMessage.sprite = fledImage;
+                Debug.Log("Fled");
 
-            finalMessage = this.GetComponent<Image>();
-            finalMessage.sprite = lostImage;
+            }
+            if (GameStateManager.died)
+            {
+                finalMessage = this.GetComponent<Image>();
+                finalMessage.sprite = diedImage;
+                Debug.Log("Died");
+
+            }
+            if (GameStateManager.lost)
+            {
+
+                finalMessage = this.GetComponent<Image>();
+                finalMessage.sprite = lostImage;
+                Debug.Log("Lost it all");
+
+            }
+
+            GameStateManager.fled = false;
+            GameStateManager.died = false;
+            GameStateManager.lost = false;
+            GameStateManager.ending = false;
+            OnEndGame.cameraPanned = false;
         }
         else {
             finalMessage = this.GetComponent<Image>();
             finalMessage.sprite = lostImage;
+            Debug.Log("Nothing Happened");
         }
+           
+        
     }
-
 }

--- a/Hold On Prototype/Assets/Scripts/GameOpening/MainMenu.cs
+++ b/Hold On Prototype/Assets/Scripts/GameOpening/MainMenu.cs
@@ -10,6 +10,7 @@ public class MainMenu : MonoBehaviour {
     public Sprite englishInstruction;
     public Sprite arabicInstruction;
     public static bool playedOnce = false;
+    GameObject gameState;
 
     public void PlayGame(){
 
@@ -26,6 +27,8 @@ public class MainMenu : MonoBehaviour {
 
     public void ReplayGame()
     {
+        gameState = GameObject.Find("GameState");
+        DestroyObject(gameState);
         playedOnce = true;
         SceneManager.LoadScene(1);
     }

--- a/Hold On Prototype/Assets/Scripts/GameStateManager.cs
+++ b/Hold On Prototype/Assets/Scripts/GameStateManager.cs
@@ -8,6 +8,7 @@ public class GameStateManager : MonoBehaviour
     public static bool fled = false;
     public static bool died = false;
     public static bool lost = false;
+    public static bool ending = false;
     public OnEndGame onEndGame;
     public Camera mainCamera;
     public Canvas canvas;
@@ -18,7 +19,9 @@ public class GameStateManager : MonoBehaviour
     public GameObject protesters;
 
     void Start()
-    {
+    {   
+        GameObject.DontDestroyOnLoad(gameObject);
+
         if (MainMenu.playedOnce)
         {
             canvas.enabled = false;
@@ -36,7 +39,7 @@ public class GameStateManager : MonoBehaviour
     void Update()
     {
 
-        if (fled | died | lost)
+        if ((fled | died | lost) && !ending)
         {
             // each frame if game has ended camera zooms out to show field damage and ongoing chaos begins the transition to final scene
             mainCamera.GetComponent<CameraController>().enabled =false;
@@ -44,6 +47,7 @@ public class GameStateManager : MonoBehaviour
 
             if (OnEndGame.cameraPanned)
             {
+                ending = true;
                 Invoke("InitiateEnding", 3);
             }
         }
@@ -62,6 +66,8 @@ public class GameStateManager : MonoBehaviour
     // function to load final scene separate from current scene and then resets the variables
     void InitiateEnding() {
         SceneManager.LoadScene("Ending", LoadSceneMode.Single);
-        ResetEndVariables();
+        Debug.Log("Loaded Scene");
+     //ResetEndVariables();
+     
     }
 }


### PR DESCRIPTION
Now game state manager persists across scene changes. Fixed error in
logic that resulted in always getting the else result in selection and
reset variables for fresh start.
